### PR TITLE
Use date-input-polyfill to select dates

### DIFF
--- a/app/templates/election_detail.html
+++ b/app/templates/election_detail.html
@@ -38,7 +38,7 @@
 
     <div class="form-group">
         <label for="birth-date">Birth Date</label>
-        <input type="date" class="form-control" id="birth-date" name="birth_date" value="{{ voter['birth_date'] }}" placeholder="mm/dd/yyyy" required pattern="(\d{4}-\d{2}-\d{2})|(\d{1,2}/\d{1,2}/\d{4})">
+        <input type="date" class="form-control" id="birth-date" name="birth_date" value="{{ voter['birth_date'] }}" placeholder="mm/dd/yyyy" required pattern="(\d{4}-\d{2}-\d{2})|(\d{1,2}/\d{1,2}/\d{4})" data-date-format="mm/dd/yyyy">
     </div>
 
     <div class="form-group">
@@ -62,6 +62,6 @@
 {% endblock %}
 {% block scripts %}
 
-<script src="https://cdn.jsdelivr.net/npm/nodep-date-input-polyfill@5.2.0/nodep-date-input-polyfill.dist.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/date-input-polyfill@2.14.0/date-input-polyfill.dist.js"></script>
 
 {% endblock %}


### PR DESCRIPTION
A user reported that `nodep-date-input-polyfill` was not working correctly on their macOS Safari browser.