### PR TITLE
Remove trailing "and" from shortened titles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,8 @@ test: install
 	poetry run pytest --failed-first --maxfail=1 --cov=app --cov-branch --cov-report=term-missing:skip-covered --cov-report=html
 	poetry run coveragespace update overall --exit-code
 
-.PHONY: watch
-watch: install
+.PHONY: dev
+dev: install
 	poetry run pytest-watch --nobeep --runner="make test" --onpass="make check && clear && echo 'All tests passed.'"
 
 ###############################################################################

--- a/app/render.py
+++ b/app/render.py
@@ -131,7 +131,7 @@ def _shorten(text: str, district: str = "") -> str:
         words.pop()
         line = " ".join(words)
 
-    return line
+    return line.removesuffix(" and")
 
 
 def _get_response(share: str, positions: List, proposals: List, votes: Dict):

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -218,3 +218,18 @@ def describe_images():
                 proposals=proposals,
                 votes={"position-5141": "candidate-99999"},
             )
+
+
+@pytest.mark.parametrize(
+    ("text", "district", "title"),
+    [
+        ("Text", "District", "Text (District)"),
+        (
+            "Countywide Law Enforcement and Safety Millage Renewal Proposition",
+            "Kalamazoo",
+            "Countywide Law Enforcement",
+        ),
+    ],
+)
+def test_shorten(expect, text, district, title):
+    expect(render._shorten(text, district)) == title  # pylint: disable=protected-access


### PR DESCRIPTION
Fixes #159